### PR TITLE
Add x402 to Payment Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ Most of these tools offer great free plans (up to 50k$ processed for free).
 - [Xero](https://www.xero.com/): Online accounting software for small businesses — starts at 20$/mo
 - [OpenNode](https://www.opennode.com/): accept Bitcoin payments (not recurring) — free plan
 - [CoinRemitter](https://coinRemitter.com/): accept Bitcoin & altcoin payments (not recurring) - 0.23% fee
+- [x402](https://github.com/xpaysh/awesome-x402): accept pay-per-call USDC payments via HTTP 402 for API monetization — no subscription needed, users pay per request
 
 ### Miscellaneous Tools & Services
 


### PR DESCRIPTION
Hi! Adding [x402](https://github.com/xpaysh/awesome-x402) to the Recurring Payment Platforms section as a crypto-native alternative for API monetization.

x402 implements HTTP 402 Payment Required for pay-per-call USDC payments — developers can monetize APIs without requiring users to set up subscriptions. It complements the existing crypto payment options (OpenNode, CoinRemitter) with a stablecoin-based, per-request model.

Thank you for maintaining this guide!