### PR TITLE
Add PageGuard - free website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ Most of these tools offer great free plans (up to 50k$ processed for free).
 - [GetTerms](https://getterms.io): A simple privacy policy generator for businesses — free plan
 - [ShipLegal](https://ship-legal.vercel.app): Generate privacy policies, terms of service & cookie policies for SaaS products. AI/LLM clauses, GDPR/CCPA — free plan
 - [Growf AI](https://www.growf.io/) - AI-powered marketing consultant that helps you research your audience, create campaigns, content and ads - free trial, starts at 199€/mo.
+- [PageGuard](https://pageguard.org) - Free all-in-one website health scanner: SEO, accessibility, and performance scores with AI analysis. — free
 
 
 ### Complete Full-stack Boilerplates


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.org) is a free all-in-one website health scanner that checks SEO, accessibility, and performance — with AI-powered analysis. No signup required.

## Why it belongs here

SaaS founders need to ensure their landing pages and web apps are healthy. PageGuard gives a quick overview of site health across three key pillars: SEO, accessibility, and performance. It's free and requires zero setup.

## Change

Added PageGuard to the **Miscellaneous Tools & Services** section.

```
- [PageGuard](https://pageguard.org) - Free all-in-one website health scanner: SEO, accessibility, and performance scores with AI analysis. — free
```