### PR TITLE
Add StackData: SaaS pricing comparison data resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ Most of these tools offer great free plans (up to 50k$ processed for free).
 - [GetTerms](https://getterms.io): A simple privacy policy generator for businesses — free plan
 - [ShipLegal](https://ship-legal.vercel.app): Generate privacy policies, terms of service & cookie policies for SaaS products. AI/LLM clauses, GDPR/CCPA — free plan
 - [Growf AI](https://www.growf.io/) - AI-powered marketing consultant that helps you research your audience, create campaigns, content and ads - free trial, starts at 199€/mo.
+- [StackData](https://greg-rg-git.github.io/stackdata-store/): SaaS pricing comparison data for 800+ tools across 15 categories — free sample + paid datasets
 
 
 ### Complete Full-stack Boilerplates


### PR DESCRIPTION
## What this adds

[StackData](https://greg-rg-git.github.io/stackdata-store/) — SaaS pricing comparison data for 800+ tools across 15 categories, with a free sample and downloadable CSV datasets.

Added to **Miscellaneous Tools & Services** as a research resource for founders benchmarking their pricing strategy.

## Why it fits

SaaS4Devs includes a "What's the best pricing strategy?" FAQ and tools for founders at every stage. StackData gives developers and bootstrappers structured data to answer the question "what do comparable tools charge?" — useful during validation and pricing decisions.

The free sample dataset is available without purchase: https://github.com/Greg-RG-GIT/stackdata-store/releases/tag/v1.0-sample