### PR TITLE
Add LLC Class: Wyoming LLC for non-US bootstrappers who need Stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,7 @@ Many developers choose a ready-made solution to handle payments because there ar
 Most of these tools offer great free plans (up to 50k$ processed for free).
 
 - [Stripe](http://www.stripe.com): the Ferrari of online payment platforms. Requires some work to set up — free plan
+- [LLC Class](https://llcclass.com): [Wyoming LLC registration](https://llcclass.com/wyoming) for non-US founders who need a US entity to access Stripe; includes [registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent) and EIN — paid service
 - [Paddle](https://paddle.com/): also handles VAT for European countries — % fee
 - [Chargebee](https://www.chargebee.com/): revenue operation for SaaS — free plan
 - [Billsby](https://www.billsby.com/): easy and accurate billing — free plan


### PR DESCRIPTION
## What this adds

Adds [LLC Class](https://llcclass.com) to the **Recurring Payment Platforms** section, directly after Stripe — for non-US bootstrappers who want to use Stripe but lack the required US business entity.

### Why it belongs here

Stripe is listed as "the Ferrari of online payment platforms" — but for many non-US bootstrappers (a large portion of the indie/micro-SaaS community), it's out of reach without a US entity. LLC Class removes that blocker:

- [Wyoming LLC registration](https://llcclass.com/wyoming) — no US address required
- [Registered agent for LLC](https://llcclass.com/what-is-llc-registered-agent) (legally required)
- EIN (US tax ID, required for Stripe + US banking)

After formation, founders can immediately apply for Stripe and Mercury bank accounts. Wyoming has no state income tax and ~$52/year annual fee — making it the most cost-effective state for non-US founders.

This complements the existing Stripe entry and addresses a real pain point for the bootstrapped SaaS developer audience this list serves.