### PR TITLE
Add SaaS Starter Lite to Full-stack Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ Most SaaS have a lot of common boilerplate, like marketing pages, login/signup f
 - [Bookstack](https://boostack.io) — NodeJS + Vue — 500$
 - [useRocket](https://userocket.herokuapp.com) — NodeJS + React — 160$
 - [Nextless JS](https://nextlessjs.com) — React + NodeJS with Serverless — 499$
+- [SaaS Starter Lite](https://github.com/sayahweb2-png/saas-starter-lite) — NestJS + Angular — free
 
 ---
 


### PR DESCRIPTION
## What is this?

Adding [SaaS Starter Lite](https://github.com/sayahweb2-png/saas-starter-lite) to the Complete Full-stack Boilerplates section.

A free (MIT), production-ready NestJS + Angular SaaS boilerplate with JWT/OAuth/2FA auth, Stripe payments, multi-tenancy, RBAC, Docker, and Terraform.

**GitHub:** https://github.com/sayahweb2-png/saas-starter-lite
**Demo:** https://demo.cloudrix.io
**License:** MIT