### PR TITLE
Add MailKite SaaS Starter to Complete Full-stack Boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ Most SaaS have a lot of common boilerplate, like marketing pages, login/signup f
 - [Bookstack](https://boostack.io) — NodeJS + Vue — 500$
 - [useRocket](https://userocket.herokuapp.com) — NodeJS + React — 160$
 - [Nextless JS](https://nextlessjs.com) — React + NodeJS with Serverless — 499$
+- [MailKite SaaS Starter](https://github.com/mailkite/saas-startup) — Next.js 15 + Stripe + Postgres + shadcn/ui — free & Open Source
 
 ---
 


### PR DESCRIPTION
Hi Nicolas 👋

Thanks for maintaining this list — it's one of the best-curated SaaS-for-develops resources, and the "Complete Full-stack Boilerplates" section is exactly where I looked when picking a starter.

I'd like to add **MailKite SaaS Starter**, a free & open-source (MIT) production-ready Next.js 15 SaaS starter. What makes it different from the other entries here: **auth runs in your own app** (Google/GitHub OAuth + email/password via JWT/sessions) — no Clerk / Auth0 / Supabase account required. It ships with Stripe subscriptions, teams, Postgres + Drizzle, and a dark-first shadcn/ui dashboard.

- **Repo:** https://github.com/mailkite/saas-startup (MIT, public)
- **Live demo:** https://saas-startup.mailkite.dev
- **Stack:** Next.js 15 · Stripe · Postgres/Drizzle · shadcn/ui · Turborepo

I matched the existing `Name — Tech — Price` format and appended it as the only Next.js 15 + shadcn/ui entry (and one of the few that's both free *and* open source). Happy to adjust the wording or placement if you'd prefer.

Thanks for considering it!